### PR TITLE
Removes warnings in the latest Xcode

### DIFF
--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -102,7 +102,7 @@
         return;
     }
         
-    NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)action);
+    NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(action));
 }
 
 - (void)eventForDatePicker:(id)sender {

--- a/Pickers/ActionSheetDistancePicker.m
+++ b/Pickers/ActionSheetDistancePicker.m
@@ -125,7 +125,7 @@
     if ([target respondsToSelector:action])
         objc_msgSend(target, action, [NSNumber numberWithInt:bigUnits], [NSNumber numberWithInt:smallUnits], origin);
     else
-        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)action);
+        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(action));
 }
 
 #pragma mark -

--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -103,7 +103,7 @@
         [target performSelector:successAction withObject:[NSNumber numberWithInt:self.selectedIndex] withObject:origin];
         return;
     }
-    NSLog(@"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)successAction);
+    NSLog(@"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(successAction));
 }
 
 - (void)notifyTarget:(id)target didCancelWithAction:(SEL)cancelAction origin:(id)origin {

--- a/Pickers/DistancePickerView.m
+++ b/Pickers/DistancePickerView.m
@@ -94,7 +94,7 @@
         if (text) {
             
             // set up the frame for the label using our longestString length
-            NSString *keyName = [NSString stringWithFormat:@"%@_%@", [NSString stringWithString:@"longestString"], [NSNumber numberWithInt:component]]; 
+            NSString *keyName = [NSString stringWithFormat:@"%@_%@", @"longestString", [NSNumber numberWithInt:component]]; 
             NSString *longestString = [labels objectForKey:keyName];
             CGRect frame;
             frame.size = [longestString sizeWithFont:labelfont];


### PR DESCRIPTION
- `(char *)SEL -> sel_getName(SEL)`
- `[NSString stringWithString:@"string"] -> @"string"`
